### PR TITLE
Set time window via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+TZ=Europe/Berlin
+TIME_START="8:30"
+TIME_END="19:00"

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-TZ=Europe/Berlin
-TIME_START="8:30"
-TIME_END="19:00"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-./breitbandmessung
+breitbandmessung
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ ENV TZ=Europe/Berlin
 # 1180x720 is absolute minimum
 ENV DISPLAY_WIDTH "1280"
 ENV DISPLAY_HEIGHT "768"
+ENV TIME_START "13:00"
+ENV TIME_END "23:00"
 
 
 VOLUME /config/xdg/config/Breitbandmessung

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker run -d \
     --name breitband-desktop \
     -e TZ=Europe/Berlin  `#optional (default)` \
     -e TIME_START="13:00" `#optional (default)` \
-    -e TIME_END="23:00" `#optional (default)` \
+    -e TIME_END="22:30" `#optional (default)` \
     -v $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung \
     -p 5800:5800 \
     fabianbees/breitbandmessung:latest
@@ -64,7 +64,7 @@ services:
     environment:
       - TZ=Europe/Berlin
       - TIME_START="13:00"
-      - TIME_END="23:00"
+      - TIME_END="22:30"
     volumes:
       - $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung
     ports:
@@ -153,7 +153,7 @@ docker build -t breitband:latest .
 ## Additional Notes
 
 - By default, the automation-script is configured to run speedtests only between 13:00 and 22:30 o'clock, because it is assumed, that the network load between 0 o'clock and 13:00 AM is lower than it is under normal use during the day.
-  To customise the time window, change the environment variables `TIME_START` and `TIME_END`, either by changing it directly in the `docker-compose.yml`, or using an `.env` file (see `.env.example`).
+  To customise the time window, change the environment variables `TIME_START` and `TIME_END`.
 
 - If you want to have more granular control for when speedtest should be run, the docker container could be stopped when no speedtest should be run, and restarted if testing should continue.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The container can be run via plain docker:
 docker run -d \
     --name breitband-desktop \
     -e TZ=Europe/Berlin  `#optional (default)` \
+    -e TIME_START="13:00" `#optional (default)` \
+    -e TIME_END="23:00" `#optional (default)` \
     -v $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung \
     -p 5800:5800 \
     fabianbees/breitbandmessung:latest
@@ -61,6 +63,8 @@ services:
     container_name: breitband-desktop
     environment:
       - TZ=Europe/Berlin
+      - TIME_START="13:00"
+      - TIME_END="23:00"
     volumes:
       - $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung
     ports:
@@ -96,7 +100,7 @@ services:
 
 ### Start automation via GUI (easy method)
 
-3. To start the script, use the website on the exposed port and put the string 'RUN' in the clipboard. To stop the script, remove the string. You may need to do this twice (error unknown). After a maximum of 15 seconds you should see the screen in action. 
+3. To start the script, use the website on the exposed port and put the string 'RUN' in the clipboard. To stop the script, remove the string. You may need to do this twice (error unknown). After a maximum of 15 seconds you should see the screen in action.
 ![Screenshot1](screenshots/clipboard.png)
 
 ```⚠️ If the clipboard method doesn't work for you, please try the following alternate method first, before opening an issue!```
@@ -148,8 +152,8 @@ docker build -t breitband:latest .
 
 ## Additional Notes
 
-- The automation-script is configured, to run speedtests only between 13:00 and 22:30 o'clock, because it is assumed, that the network load between 0 o'clock and 13:00 AM is lower than it is under normal use during the day.
-(This behaviour could be alterd, by changing the values in the **if statement in line 18** of the file ```run-speedtest.sh``` before building the docker image).
+- By default, the automation-script is configured to run speedtests only between 13:00 and 22:30 o'clock, because it is assumed, that the network load between 0 o'clock and 13:00 AM is lower than it is under normal use during the day.
+  To customise the time window, change the environment variables `TIME_START` and `TIME_END`, either by changing it directly in the `docker-compose.yml`, or using an `.env` file (see `.env.example`).
 
 - If you want to have more granular control for when speedtest should be run, the docker container could be stopped when no speedtest should be run, and restarted if testing should continue.
 

--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -9,6 +9,8 @@ services:
     container_name: breitband-desktop
     environment:
       - TZ=Europe/Berlin
+      - TIME_START
+      - TIME_END
     volumes:
       - ${APPDATA}:/config/xdg/config/Breitbandmessung
     ports:

--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -9,8 +9,8 @@ services:
     container_name: breitband-desktop
     environment:
       - TZ=Europe/Berlin
-      - TIME_START
-      - TIME_END
+      - TIME_START="13:00"
+      - TIME_END="22:30"
     volumes:
       - ${APPDATA}:/config/xdg/config/Breitbandmessung
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     container_name: breitband-desktop
     environment:
       - TZ=Europe/Berlin
+      - TIME_START
+      - TIME_END
     volumes:
       - $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     container_name: breitband-desktop
     environment:
       - TZ=Europe/Berlin
-      - TIME_START
-      - TIME_END
+      - TIME_START="13:00"
+      - TIME_END="22:30"
     volumes:
       - $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung
     ports:

--- a/rootfs/etc/services.d/speedtest/run
+++ b/rootfs/etc/services.d/speedtest/run
@@ -78,8 +78,8 @@ do
 
 
             # wait 6 minutes
-            sleep 360
             echo "waiting 6 minutes..."
+            sleep 360
 
 
         else

--- a/rootfs/etc/services.d/speedtest/run
+++ b/rootfs/etc/services.d/speedtest/run
@@ -2,6 +2,18 @@
 
 # this script is invoced every 6 minutes if clipboard is set to 'RUN', then a speedtest runs
 
+time_to_minutes() {
+    local TIME="$1"
+    IFS=':' read -r HOUR MINUTE <<< "$TIME"
+    if ! [[ "$HOUR" =~ ^[0-9]+$ && "$MINUTE" =~ ^[0-9]+$ ]]; then
+        echo "Invalid time format. Use HH:MM or H:MM" >&2
+        return 1
+    fi
+    echo $(( $HOUR*60 + $MINUTE ))
+}
+
+start_time_minutes=$(time_to_minutes $TIME_START)
+end_time_minutes=$(time_to_minutes $TIME_END)
 
 while true
 do
@@ -21,32 +33,25 @@ do
         # Get the current hour and minute in 24-hour format (e.g., 14:30)
         current_time=$(date +"%H:%M:%S")
         echo "Current time is $current_time"
-        
-        
+
+
         # Save the hour and minute
         current_hour=$(date +"%H")
         current_minute=$(date +"%M")
         current_hour=${current_hour#0}
         current_minute=${current_minute#0}
 
-        # Convert the start and end times to minutes for easier comparison
-        # 13:00 in minutes
-        start_time_minutes=$(( 13 * 60 ))
-        # 22:30 in minutes
-        end_time_minutes=$(( 22 * 60 + 30 ))
-
-
         # Convert the current time to minutes for comparison
         let "current_time_minutes=$current_hour * 60 + $current_minute"
 
-        
+
         # Check if the current time is within the specified range
         # --> only start speedtesting during daytime, as this is the most relevant metric
         if (( current_time_minutes >= start_time_minutes && current_time_minutes <= end_time_minutes ))
         then
-            echo "The current time is between 13:00 and 22:30."
+            echo "The current time is between $TIME_START and $TIME_END."
             echo "Trying to start speedtest..."
-            
+
             # messung durchfuehren
             DISPLAY=:0 xdotool mousemove 531 510
             DISPLAY=:0 xdotool click 1
@@ -76,9 +81,9 @@ do
             sleep 360
             echo "waiting 6 minutes..."
 
-        
+
         else
-            echo "NOT STARTING. The current time is outside the specified range of 13:00 and 22:30."
+            echo "NOT STARTING. The current time is outside the specified range of $TIME_START and $TIME_END."
         fi
 
 


### PR DESCRIPTION
Implements #26

The time window can be adjusted by setting two new environment variables `TIME_START` and `TIME_END`. It defaults to the currently set time window.

Example:

```yml
version: "3.8"
services:
  breitband-desktop:
    image: fabianbees/breitbandmessung:latest
    container_name: breitband-desktop
    environment:
      - TZ=Europe/Berlin
      - TIME_START="13:00"
      - TIME_END="22:30"
    volumes:
      - $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung
    ports:
      - 5800:5800
    restart: unless-stopped
```

I added a test for checking if there are numbers before and after the colon, this is not very elaborate and the regex could be improved. In my opinion, it serves the purpose.

Also, this PR adds a minor fix to the verbose output.

I'd be happy to see this one in master. Thanks for the work to @fabianbees and the contributors to this repo :+1: 