### PR TITLE
actions(build_docker_image.yml): Bump docker/build-push-action from 5 to 6

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build and push main Docker image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           build-args: GH_TOKEN=${{ github.token }}
           context: .


### PR DESCRIPTION
This bumps the github action dependency [docker/build-push-action](https://github.com/docker/build-push-action) from 5 to 6.
- [Release notes](https://github.com/docker/build-push-action/releases)
- [Commits](https://github.com/docker/build-push-action/compare/v5...v6)
