### PR TITLE
Update base to 24.04-v4 baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Pull base image.
-FROM jlesage/baseimage-gui:ubuntu-22.04-v4
+FROM jlesage/baseimage-gui:ubuntu-24.04-v4
 
 
 # Install packages
 RUN apt update && apt upgrade -yy && \
-  apt install -y apt-utils nano libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm-dev libxss1 libasound2 wget xterm libnss3 locales xdotool xclip && \
+  apt install -y apt-utils nano libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm-dev libxss1 libasound2t64 wget xterm libnss3 locales xdotool xclip && \
   locale-gen de_DE.UTF-8 && \
   rm -rf /var/cache/apt /var/lib/apt/lists
 


### PR DESCRIPTION
#### This updates the base image used from Ubuntu 22.04 to Ubuntu 24.04.

- No errors occurred while building or using the container.
- The speed test schedule with the `RUN` trigger also continues to work.