### PR TITLE
Fix: `Legacy key/value format with whitespace separator should not be used` Docker Build warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN \
 # Timezone can be overwritten via docker environment variable
 ENV TZ=Europe/Berlin
 # 1180x720 is absolute minimum
-ENV DISPLAY_WIDTH "1280"
-ENV DISPLAY_HEIGHT "768"
+ENV DISPLAY_WIDTH="1280"
+ENV DISPLAY_HEIGHT="768"
 
 
 VOLUME /config/xdg/config/Breitbandmessung


### PR DESCRIPTION
This fixes 2 Docker Build warnings because using Legycy key/value format with whitespace separator.
<img width="1279" height="205" alt="Screenshot 2025-12-04 at 15-48-58 Bump jlesage_baseimage-gui - ubuntu 22 04 to 24 04 · LizenzFass78851_breitbandmessung-docker@a8a7e7b" src="https://github.com/user-attachments/assets/d0a3ffa4-aec7-4d86-96ea-cdc7c3897c86" />

https://github.com/fabianbees/breitbandmessung-docker/actions/runs/19902071945
See: `Annotations`