### PR TITLE
Add a Workflow to Cleanup untagged ghcr Packages

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,25 @@
+name: Remove untagged images from registry
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * 0"
+
+jobs:
+  remove_untagged_images:
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'schedule' && github.repository_owner == 'fabianbees') || github.event_name != 'schedule'  }}
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Delete all containers from package without tags
+        uses: Chizkiyahu/delete-untagged-ghcr-action@main
+        with:
+          token: ${{ github.token }}
+          repository_owner: ${{ github.repository_owner }}
+          repository: ${{ github.repository }}
+          package_name: ${{ github.event.repository.name }}
+          untagged_only: true
+          owner_type: user # or org
+          except_untagged_multiplatform: true 

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -3,12 +3,12 @@ name: Remove untagged images from registry
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 1 * * 0"
+    - cron: "0 1 1 * *"
 
 jobs:
   remove_untagged_images:
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'schedule' && github.repository_owner == 'fabianbees') || github.event_name != 'schedule'  }}
+    if: ${{ (github.event_name == 'schedule' && github.repository_owner == 'fabianbees') || github.event_name != 'schedule' }}
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
This adds a new workflow that cleans up untagged images (packages) from the ghcr registry.

These untagged images (packages) are created when, for example, a Docker image with the "latest" tag is re-pushed. The image that was previously "latest" is now untagged and is replaced by the newly pushed one. The untagged image is not deleted and remains in the ghcr registry and, as mentioned, is unnecessary since these untagged images can no longer be assigned a tag.

You have to manually initiate a workflow to clean up these untagged images.
See: https://github.com/fabianbees/breitbandmessung-docker/pkgs/container/breitbandmessung-docker/versions?filters%5Bversion_type%5D=untagged to view the own untagged images.

