### PR TITLE
Change /RUN check from -f to -e to enable check against anything

### DIFF
--- a/rootfs/etc/services.d/speedtest/run
+++ b/rootfs/etc/services.d/speedtest/run
@@ -25,7 +25,7 @@ do
     clipboard="$(DISPLAY=:0 xclip -o)"
 
     # check if /RUN File exists, or if clipboard is set to 'RUN'
-    if [ "$clipboard" == "RUN" ] || [ -f "/RUN" ]
+    if [ "$clipboard" == "RUN" ] || [ -e "/RUN" ]
     then
         echo "Run set!"
 


### PR DESCRIPTION
If you'd want to enable /RUN on start, you'd need to add a volume mount in your docker call to i.e. /dev/null:/RUN

But test -f checks for regular files. Change the test condition to -e for anything that exists and you are good to go.

This is required to enabled my other change in PR: https://github.com/fabianbees/breitbandmessung-docker/pull/43