### PR TITLE
Fix time format handling to remove leading zero

### DIFF
--- a/rootfs/etc/services.d/speedtest/run
+++ b/rootfs/etc/services.d/speedtest/run
@@ -9,7 +9,7 @@ time_to_minutes() {
         echo "Invalid time format. Use HH:MM or H:MM" >&2
         return 1
     fi
-    echo $(( $HOUR*60 + $MINUTE ))
+    echo $(( ${HOUR#0}*60 + $MINUTE ))
 }
 
 start_time_minutes=$(time_to_minutes $TIME_START)


### PR DESCRIPTION
Adding same check as you do in line 41.
If you'd have a time_start or time_end with 08 or 09 as the HOUR, it'd give you: -bash: 08: value too great for base (error token is "08")