### PR TITLE
Auto-Update logic using official latest-linux.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/breitbandmessung"
-  VERSION: "3.12.0"
+  VERSION: "3.12.1"
 
 # Build Stages
 stages:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ COPY rootfs/ /
 # see: https://download.breitbandmessung.de/bbm/
 RUN \
     set-cont-env APP_NAME "Breitbandmessung" && \
-    set-cont-env APP_VERSION "3.12.0" && \
-    set-cont-env APP_SHA256SUM "df041550d4e3160a05069cb41a5d6bfc511d82a46b763337485a8fa65eb3e8ee" && \
+    set-cont-env APP_VERSION "3.12.1" && \
+    set-cont-env APP_SHA256SUM "b948331a4e8df0fcbdd6fbace588770e62b4c61e7e279c6a0f79ef581de080f1" && \
+    set-cont-env CHECK_FOR_UPDATES "true" && \
     set-cont-env DEBIAN_FRONTEND "noninteractive" && \
     set-cont-env LANG "de_DE.UTF-8" &&  \
     true

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ docker run -d \
     -e TZ=Europe/Berlin  `#optional (default)` \
     -e TIME_START="13:00" `#optional (default)` \
     -e TIME_END="22:30" `#optional (default)` \
+    -e CHECK_FOR_UPDATES="true" `#optional (default)` \
     -v $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung \
     -p 5800:5800 \
     fabianbees/breitbandmessung:latest
@@ -64,6 +65,7 @@ services:
       TZ: Europe/Berlin
       TIME_START: "13:00"
       TIME_END: "22:30"
+      CHECK_FOR_UPDATES: "true"
     volumes:
       - $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung
     ports:
@@ -150,6 +152,8 @@ docker build -t breitband:latest .
 
 
 ## Additional Notes
+
+- **Auto-Updates:** By default, the container checks for the latest version of the Breitbandmessung app on every start using the official `latest-linux.yml`. It only downloads and installs updates if the online version differs from the installed one. To disable this, set `CHECK_FOR_UPDATES` to `"false"`.
 
 - By default, the automation-script is configured to run speedtests only between 13:00 and 22:30 o'clock, because it is assumed, that the network load between 0 o'clock and 13:00 AM is lower than it is under normal use during the day.
   To customise the time window, change the environment variables `TIME_START` and `TIME_END`.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ docker build -t breitband:latest .
 
 ## Additional Notes
 
-- **Auto-Updates:** By default, the container checks for the latest version of the Breitbandmessung app on every start using the official `latest-linux.yml`. It only downloads and installs updates if the online version differs from the installed one. To disable this, set `CHECK_FOR_UPDATES` to `"false"`.
+- **Auto-Updates:** By default, the container checks for the latest version of the Breitbandmessung app on every start using the official [latest-linux.yml](https://download.breitbandmessung.de/bbm/latest-linux.yml). It only downloads and installs updates if the online version differs from the installed one. To disable this, set `CHECK_FOR_UPDATES` to `"false"`.
 
 - By default, the automation-script is configured to run speedtests only between 13:00 and 22:30 o'clock, because it is assumed, that the network load between 0 o'clock and 13:00 AM is lower than it is under normal use during the day.
   To customise the time window, change the environment variables `TIME_START` and `TIME_END`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       TZ: Europe/Berlin
       TIME_START: "13:00"
       TIME_END: "22:30"
+      CHECK_FOR_UPDATES: "true"
     volumes:
       - $PWD/breitbandmessung/data:/config/xdg/config/Breitbandmessung
     ports:

--- a/rootfs/etc/cont-init.d/50-install-latest-breitbandmessung.sh
+++ b/rootfs/etc/cont-init.d/50-install-latest-breitbandmessung.sh
@@ -1,39 +1,79 @@
 #!/bin/bash
+# Breitbandmessung Installer for Docker
+# This script handles dynamic updates via latest-linux.yml
+set -e          # Exit immediately if a command exits with a non-zero status.
+set -u          # Treat unset variables as an error.
+set -o pipefail # The return value of a pipeline is the status of the last command to exit with a non-zero status.
 
-set -e # Exit immediately if a command exits with a non-zero status.
-set -u # Treat unset variables as an error.
+# Config
+YAML_URL="https://download.breitbandmessung.de/bbm/latest-linux.yml"
+BASE_URL="https://download.breitbandmessung.de/bbm"
+CHECK_FOR_UPDATES="${CHECK_FOR_UPDATES:-true}"
+VERSION_FILE="/VERSION"
+HASH_FILE="/VERSION.hash"
+DEB_TEMP="/tmp/breitbandmessung.deb"
 
+log() { echo "[Installer] $*"; }
 
-# check if /VERSION File exists, --> only installing on first container start, afterwards skip ...
-if [ -f "/VERSION" ]
-then
-    echo "App already installed, not installing again."
-    echo "Version is: $(sed -n "/^$APP_VERSION/p;q" /VERSION)"
+# Cleanup: Delete the installer package on exit (success or failure)
+cleanup() { rm -f "$DEB_TEMP"; }
+trap cleanup EXIT
+
+# 1. Gather information (Defaults from Dockerfile)
+INSTALL_VERSION="$APP_VERSION"
+INSTALL_SHA="$APP_SHA256SUM"
+INSTALL_PATH="Breitbandmessung-$APP_VERSION-linux.deb"
+HASH_TYPE="sha256"
+
+if [ "$CHECK_FOR_UPDATES" = "true" ]; then
+    log "Checking for latest version at $YAML_URL..."
+    if YAML=$(wget -qO- "$YAML_URL"); then
+        # Parse version info from YAML
+        ONLINE_VERSION=$(echo "$YAML" | sed -n 's/^version: //p' | tr -d '\r' | head -n1)
+        ONLINE_SHA_B64=$(echo "$YAML" | sed -n 's/^sha512: //p' | tr -d '\r' | head -n1)
+        ONLINE_PATH=$(echo "$YAML" | sed -n 's/^path: //p' | tr -d '\r' | head -n1)
+
+        if [ -n "$ONLINE_VERSION" ] && [ -n "$ONLINE_SHA_B64" ]; then
+            INSTALL_VERSION="$ONLINE_VERSION"
+            INSTALL_SHA=$(echo "$ONLINE_SHA_B64" | base64 -d | od -v -t x1 -An | tr -d ' \n')
+            INSTALL_PATH="$ONLINE_PATH"
+            HASH_TYPE="sha512"
+            log "Latest online version is $INSTALL_VERSION"
+        else
+            log "Failed to parse YAML. Falling back to $APP_VERSION."
+        fi
+    else
+        log "Download of YAML failed. Falling back to $APP_VERSION."
+    fi
+else
+    log "Update check disabled. Using version $APP_VERSION."
+fi
+
+# 2. Check if installation or update is required (Hash-based)
+if [ -f "$HASH_FILE" ] && [ "$(cat "$HASH_FILE")" = "$INSTALL_SHA" ]; then
+    log "App already installed and up to date ($INSTALL_VERSION). Skipping."
     exit 0
 fi
 
+# 3. Download and Verify
+log "Installing Version $INSTALL_VERSION..."
+wget -q "$BASE_URL/$INSTALL_PATH" -O "$DEB_TEMP"
 
-# Otherwiese install breitbandmessung-dektop ...
-echo "Installing Version $APP_VERSION (sha256:$APP_SHA256SUM)"
+log "Verifying $HASH_TYPE checksum..."
+ACTUAL_SHA=$("${HASH_TYPE}sum" "$DEB_TEMP" | cut -d' ' -f1)
 
-# Download latest breitbandmessung-app
-wget "https://download.breitbandmessung.de/bbm/Breitbandmessung-$APP_VERSION-linux.deb"
-echo "$APP_SHA256SUM  Breitbandmessung-$APP_VERSION-linux.deb" | sha256sum -c
-retVal=$?
-if [ $retVal -ne 0 ]; then
-    echo "Checksum mismatch"
-else
-    echo "Checksum matches, installing ..."
+if [ "$ACTUAL_SHA" != "$INSTALL_SHA" ]; then
+    log "CRITICAL: Checksum mismatch! (Expected: $INSTALL_SHA, Got: $ACTUAL_SHA)"
+    exit 1
 fi
 
+# 4. Install .deb package
+log "Installing package..."
+# Needed because group 'messagebus' does not exist at this time
+sed -i '/messagebus/d' /var/lib/dpkg/statoverride || true
+dpkg -i "$DEB_TEMP"
 
-# Install .deb file
-sed -i '/messagebus/d' /var/lib/dpkg/statoverride   # needed because group does not exist at this time
-dpkg -i "Breitbandmessung-$APP_VERSION-linux.deb"
-
-
-# Save version info in /VERSION file
-dpkg-deb -f "Breitbandmessung-${APP_VERSION}-linux.deb" Version > /VERSION
-# Delete install package
-rm "Breitbandmessung-$APP_VERSION-linux.deb"
-
+# 5. Save state for next container start
+echo "$INSTALL_VERSION" > "$VERSION_FILE"
+echo "$INSTALL_SHA" > "$HASH_FILE"
+log "Installation of Breitbandmessung $INSTALL_VERSION successful."


### PR DESCRIPTION
This PR introduces an automated way to keep the Breitbandmessung app up to date within the container.

#### Key Changes:
*   **Dynamic Update Check:** The container now fetches and parses the official [latest-linux.yml](https://download.breitbandmessung.de/bbm/latest-linux.yml) on every start to detect new versions automatically.
*   **Hardened Installer Script:**
    *   Added `set -euo pipefail` for better error handling.
    *   Implemented an `EXIT` trap to ensure temporary `.deb` files are always cleaned up, even if the installation fails.
*   **New Environment Variable:** Introduced `CHECK_FOR_UPDATES` (default: `true`). Setting this to `false` will skip the online check and use the fallback version defined in the Dockerfile.
*   **Updated Fallbacks:** Bumped the default app version and its SHA256 hash to `3.12.1` in `Dockerfile`, `.gitlab-ci.yml`, and the installer script.
*   **Documentation:** Updated `README.md` and `docker-compose.yml` to reflect the new update logic and configuration options.

#### Verified Scenarios:
- [x] Initial installation of latest version.
- [x] Skipping download when the installed version (hash) matches the online version.
- [x] Triggering update when a hash mismatch is detected.
- [x] Safe fallback to hardcoded values when `CHECK_FOR_UPDATES=false` or offline/fail.